### PR TITLE
fix: Article duplication

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/service/article/ArticleServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/service/article/ArticleServiceImpl.java
@@ -62,7 +62,16 @@ public class ArticleServiceImpl implements ArticleService {
     public List<ArticleDto> saveAll(List<ArticleDto> articles) {
         List<ArticleEntity> list = articles.stream().map(ArticleMapper::map).toList();
 
-        List<ArticleEntity> articleEntities = articleJpaRepository.saveAll(list);
+        List<String> existing = articleJpaRepository.findBySlugIsIn(list.stream().map(ArticleEntity::getSlug).toList())
+                .stream().map(ArticleEntity::getSlug).toList();
+
+        List<ArticleEntity> nonExisting = list
+                .stream().filter(
+                        e -> !existing.contains(e.getSlug())
+                )
+                .toList();
+
+        List<ArticleEntity> articleEntities = articleJpaRepository.saveAll(nonExisting);
 
         return articleEntities.stream().map(ArticleMapper::map).toList();
     }

--- a/backend/src/main/java/com/example/backend/infrastructure/database/repository/ArticleJpaRepository.java
+++ b/backend/src/main/java/com/example/backend/infrastructure/database/repository/ArticleJpaRepository.java
@@ -17,6 +17,7 @@ public interface ArticleJpaRepository extends JpaRepository<ArticleEntity, Strin
 
     List<ArticleEntity> findAll(Specification<ArticleEntity> spec, Pageable pageable);
 
+    List<ArticleEntity> findBySlugIsIn(List<String> slugs);
     /**
      * Version with pagination and sorting.
      * Finds unique articles related to stocks observed by a specific user.


### PR DESCRIPTION
This pull request introduces a change to prevent duplicate entries when saving articles in bulk by checking for existing slugs in the database. The most important changes include modifying the `saveAll` method in `ArticleServiceImpl` to filter out existing articles and adding a new repository method to query articles by their slugs.

### Changes to prevent duplicate entries:

* [`backend/src/main/java/com/example/backend/domain/service/article/ArticleServiceImpl.java`](diffhunk://#diff-3b926c2f48532d3059d2fa61985cc6c15935f4046d422dbdf2aa0896f8bb49bfL65-R74): Updated the `saveAll` method to query the database for existing slugs, filter out articles with those slugs, and only save non-existing articles. This ensures no duplicates are saved.
* [`backend/src/main/java/com/example/backend/infrastructure/database/repository/ArticleJpaRepository.java`](diffhunk://#diff-5398e948ec254f0bad997551ccf3e28f80c638da5a652433949808730a820047R20): Added a new method `findBySlugIsIn` to fetch articles by a list of slugs, enabling the filtering logic in the service layer.