### PR TITLE
fix(backend): Do not return impact "none"

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/dto/mapper/ArticleMapper.java
+++ b/backend/src/main/java/com/example/backend/domain/dto/mapper/ArticleMapper.java
@@ -42,6 +42,7 @@ public class ArticleMapper {
                 .stocks(impacts == null ? Collections.emptyList() :
                         impacts
                                 .stream()
+                                .filter(entity -> !entity.getImpact().equals("none"))
                                 .map(entity ->
                                         SymbolWithImpact.builder()
                                                 .symbol(entity.getStock().getSymbol())


### PR DESCRIPTION
This pull request includes a small but important change to the `ArticleMapper` class. The change adds a filter to exclude entities with an impact value of `"none"` when mapping `impacts` to `SymbolWithImpact` objects.