### PR TITLE
feat(backend): Add endpoint to retrieve articles by stock symbol

### DIFF
--- a/backend/src/main/java/com/example/backend/api/ArticlesController.java
+++ b/backend/src/main/java/com/example/backend/api/ArticlesController.java
@@ -271,4 +271,20 @@ public class ArticlesController {
             return ResponseEntity.internalServerError().body(message);
         }
     }
+
+    @GetMapping("/articles/stock/{symbol}")
+    public ResponseEntity<List<ArticleDto>> getStockArticles(
+            @PathVariable String symbol,
+            @RequestParam(name = "page", defaultValue = "0") Integer pageNumber,
+            @RequestParam(name = "size", defaultValue = "10") Integer size
+    ) {
+        try {
+            log.info("Fetching articles for stock with symbol: {}", symbol);
+            List<ArticleDto> articles = articleService.findByStockSymbol(symbol, pageNumber, size);
+            return ResponseEntity.ok(articles);
+        } catch (Exception e) {
+            log.error("Error fetching articles for stock with symbol: {}", symbol, e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/service/article/ArticleService.java
+++ b/backend/src/main/java/com/example/backend/domain/service/article/ArticleService.java
@@ -19,4 +19,6 @@ public interface ArticleService {
     List<ArticleDto> getArticlesForUser(ArticleSearchParams params, String email);
 
     Optional<ArticleDto> findBySlug(String slug);
+
+    List<ArticleDto> findByStockSymbol(String stockSymbol, int pageNumber, int size);
 }

--- a/backend/src/main/java/com/example/backend/infrastructure/database/repository/ArticleStockImpactJpaRepository.java
+++ b/backend/src/main/java/com/example/backend/infrastructure/database/repository/ArticleStockImpactJpaRepository.java
@@ -1,9 +1,13 @@
 package com.example.backend.infrastructure.database.repository;
 
 import com.example.backend.infrastructure.database.entity.ArticleStockImpactEntity;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ArticleStockImpactJpaRepository extends JpaRepository<ArticleStockImpactEntity, String> {
+    List<ArticleStockImpactEntity> findAllByStockSymbol(String symbol, Pageable pageable);
 }


### PR DESCRIPTION
This pull request introduces a new feature to fetch articles related to a specific stock symbol, along with some related improvements in sorting and repository methods. Below is a summary of the most important changes grouped by theme:

### New Feature: Fetch Stock Articles
* Added a new endpoint `GET /articles/stock/{symbol}` in `ArticlesController` to fetch articles for a specific stock symbol, with pagination support. This includes proper logging and error handling.
* Introduced a new method `findByStockSymbol(String stockSymbol, int pageNumber, int size)` in the `ArticleService` interface and implemented it in `ArticleServiceImpl`. This method retrieves stock articles while filtering out those with "none" impact. [[1]](diffhunk://#diff-4209b7ac0864ec350333e649ff77bac8b6cc0742c8986471e1d4028082aad996R22-R23) [[2]](diffhunk://#diff-3b926c2f48532d3059d2fa61985cc6c15935f4046d422dbdf2aa0896f8bb49bfL100-R116)

### Repository Enhancements
* Added a new repository method `findAllByStockSymbol(String symbol, Pageable pageable)` in `ArticleStockImpactJpaRepository` to support the stock article query.
* Injected `ArticleStockImpactJpaRepository` into `ArticleServiceImpl` to enable querying stock-related articles. [[1]](diffhunk://#diff-3b926c2f48532d3059d2fa61985cc6c15935f4046d422dbdf2aa0896f8bb49bfR10) [[2]](diffhunk://#diff-3b926c2f48532d3059d2fa61985cc6c15935f4046d422dbdf2aa0896f8bb49bfR38)

### Sorting Improvement
* Updated the `getArticlesForUser` method in `ArticleServiceImpl` to sort articles by `publishedAt` instead of `id` for a more meaningful ordering.