### PR TITLE
fix(backend): Fix pagination in getStockArticles

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/service/article/ArticleServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/service/article/ArticleServiceImpl.java
@@ -110,7 +110,6 @@ public class ArticleServiceImpl implements ArticleService {
     @Override
     public List<ArticleDto> findByStockSymbol(String stockSymbol, int pageNumber, int size) {
             return articleStockImpactJpaRepository.findAllByStockSymbol(stockSymbol, PageRequest.of(pageNumber, size)).stream()
-                    .filter(impact -> !impact.getImpact().equals("none"))
                     .map(impact -> ArticleMapper.map(impact.getArticle()))
                     .toList();
     }

--- a/backend/src/main/java/com/example/backend/infrastructure/database/repository/ArticleStockImpactJpaRepository.java
+++ b/backend/src/main/java/com/example/backend/infrastructure/database/repository/ArticleStockImpactJpaRepository.java
@@ -3,11 +3,14 @@ package com.example.backend.infrastructure.database.repository;
 import com.example.backend.infrastructure.database.entity.ArticleStockImpactEntity;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface ArticleStockImpactJpaRepository extends JpaRepository<ArticleStockImpactEntity, String> {
-    List<ArticleStockImpactEntity> findAllByStockSymbol(String symbol, Pageable pageable);
+    @Query("SELECT a FROM ArticleStockImpactEntity a WHERE a.stock.symbol = :symbol AND a.impact <> 'none'")
+    List<ArticleStockImpactEntity> findAllByStockSymbol(@Param("symbol") String symbol, Pageable pageable);
 }


### PR DESCRIPTION
This pull request refactors how articles are fetched by stock symbol in the backend service. The most significant change is moving the filtering logic for articles with no impact from the service layer to the repository layer by introducing a custom query.

### Backend service improvements:

* [`backend/src/main/java/com/example/backend/domain/service/article/ArticleServiceImpl.java`](diffhunk://#diff-3b926c2f48532d3059d2fa61985cc6c15935f4046d422dbdf2aa0896f8bb49bfL113): Removed the filtering logic for articles with no impact (`impact.equals("none")`) from the service layer.

### Repository enhancements:

* [`backend/src/main/java/com/example/backend/infrastructure/database/repository/ArticleStockImpactJpaRepository.java`](diffhunk://#diff-01016cd3ad1f3a0564ef8916f6cb9b9fe2f05f4f20a68bbbd46e65d12e089cd3R6-R15): Added a custom JPA query to filter out articles with no impact directly at the database level, improving efficiency.